### PR TITLE
Adjust post gain range

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ impl Default for SubrouRsParams {
             post_gain: FloatParam::new(
                 "Post Gain",
                 1.0,
-                FloatRange::Linear { min: 0.0, max: 1.0 },
+                FloatRange::Linear { min: 0.0, max: 5.0 },
             ),
             pitch: FloatParam::new(
                 "Pitch",


### PR DESCRIPTION
## Summary
- widen post gain parameter range from 1.0 to 5.0

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6855acd6c4b4832784bb6afb151dd6af