### PR TITLE
Allow gain up to 12dB

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@ impl Default for SubrouRsParams {
                 1.0,
                 FloatRange::Skewed {
                     min: 0.0,
-                    max: util::db_to_gain(6.0),
-                    factor: FloatRange::gain_skew_factor(util::MINUS_INFINITY_DB, 6.0),
+                    max: util::db_to_gain(12.0),
+                    factor: FloatRange::gain_skew_factor(util::MINUS_INFINITY_DB, 12.0),
                 },
             )
             .with_smoother(SmoothingStyle::Logarithmic(10.0))


### PR DESCRIPTION
## Summary
- expand gain parameter range to 12dB

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6856d31681f48327957c637e81be8cba